### PR TITLE
Define pip dependencies in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,19 @@ The jupyter notebook file contains methods to access the data.
 Installation
 ---
 
-For an Anaconda environment, where `pip` is available, please `cd`
-to the appropriate package directory, where the `setup.py` file is
-located and type either
+For an Anaconda environment, where `pip` is available, odenet can be installed by using the following command:
 
-`pip install .`
+```bash
+> pip install git+https://github.com/hdaSprachtechnologie/odenet
+```
 
 for a user installation or
 
-`pip install -e .`
+```bash
+> git clone https://github.com/hdaSprachtechnologie/odenet
+> cd odenet
+> pip install -e .
+```
 
 for a developer installation (`-e` for editable). 
 

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,9 @@ setup(
           'Topic :: Education',
           'Topic :: Text Processing :: Linguistic'
     ],
+    install_requires=[
+      'networkx',
+      'matplotlib'
+    ],
     long_description=long_description
 )


### PR DESCRIPTION
This pull request adds an `install_requires`-entry to setup.py, making it possible to install the package directly from github together with all dependencies required by it.

The readme has also been updated with steps for doing so, namely by issuing the command:
```bash
> pip install git+https://github.com/hdaSprachtechnologie/odenet
```